### PR TITLE
Fix optpmap.py "Can't pickle local object" multiprocessing error

### DIFF
--- a/optpmap.py
+++ b/optpmap.py
@@ -21,6 +21,17 @@ def _init(current: Synchronized[int], total: Synchronized[int]):
 T = TypeVar('T')
 
 
+def _wrapped_func(func_and_args: tuple[Callable[..., T], *tuple[Any, ...]]) -> T:
+    func = func_and_args[0]
+    args = func_and_args[1:]
+
+    with _current.get_lock():
+        _current.value += 1
+    sys.stdout.write('\r\t{} of {}'.format(_current.value, _total.value))
+    sys.stdout.flush()
+
+    return func(*args)
+
 def parallel_map(func: Callable[..., T], iterable: ItemsView[Any, Any], processes: int, *args: object) -> list[T]:
     """
     A parallel map function that reports on its progress.
@@ -34,16 +45,6 @@ def parallel_map(func: Callable[..., T], iterable: ItemsView[Any, Any], processe
     _current = multiprocessing.Value('i', 0)
     _total = multiprocessing.Value('i', len(iterable))
 
-    def _wrapped_func(func_and_args: tuple[Callable[..., T], *tuple[Any, ...]]) -> T:
-        func = func_and_args[0]
-        args = func_and_args[1:]
-
-        with _current.get_lock():
-            _current.value += 1
-        sys.stdout.write('\r\t{} of {}'.format(_current.value, _total.value))
-        sys.stdout.flush()
-
-        return func(*args)
     func_and_args = [(func, it_arg, *args) for it_arg in iterable]
     if processes == 1:
         result: list[T] = list(map(_wrapped_func, func_and_args))


### PR DESCRIPTION
Without this patch the script fails on macos with Python 3.13 with the following error:
```none
Traceback (most recent call last):
  File "~/optview2/cpp_optimization_example/../opt-viewer.py", line 529, in <module>
    main()
    ~~~~^^
  File "~/optview2/cpp_optimization_example/../opt-viewer.py", line 508, in main
    gather_results(filenames=files, num_jobs=args.jobs,
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   exclude_names=args.exclude_names,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   exclude_text=args.exclude_text,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   collect_opt_success=args.collect_opt_success,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   annotate_external=args.annotate_external)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/optview2/optrecord.py", line 364, in gather_results
    remarks = optpmap.parallel_map(
        get_remarks, filenames, num_jobs, exclude_names, exclude_text, collect_opt_success, annotate_external)
  File "~/optview2/optpmap.py", line 55, in parallel_map
    result = pool.map(_wrapped_func, func_and_args)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/pool.py", line 774, in get
    raise self._value
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/pool.py", line 540, in _handle_tasks
    put(task)
    ~~~^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/connection.py", line 206, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
                     ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
AttributeError: Can't get local object 'parallel_map.<locals>._wrapped_func'
```